### PR TITLE
Add Contribute page to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,37 @@ SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model project <dynam
 SPDX-License-Identifier: MPL-2.0
 -->
 # Power Gird Model Benchmark
+
 `power-grid-model-benchmark` is a benchmark example of [power-grid-model](https://github.com/PowerGridModel/power-grid-model) in a jupyter notebook on your local machine.
 
 ## Instructions
 
 ### Locally
+
 Install:
 `pip install -r requirements.txt`
 
 Run:
 `jupyter notebook`
 
+## License
 
-# License
 This project is licensed under the Mozilla Public License, version 2.0 - see [LICENSE](LICENSE) for details.
 
-# Licenses third-party libraries
+## Licenses third-party libraries
+
 This project includes third-party libraries, 
 which are licensed under their own respective Open-Source licenses.
 SPDX-License-Identifier headers are used to show which license is applicable. 
 The concerning license files can be found in the LICENSES directory.
 
-# Contributing
+## Contributing
+
 Please read [CODE_OF_CONDUCT](https://github.com/PowerGridModel/.github/blob/main/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/PowerGridModel/.github/blob/main/CONTRIBUTING.md) for details on the process 
 for submitting pull requests to us.
 
-# Contact
+Visit [Contribute](https://github.com/PowerGridModel/power-grid-model-benchmark/contribute) for a list of good first issues in this repo.
+
+## Contact
+
 Please read [SUPPORT](https://github.com/PowerGridModel/.github/blob/main/SUPPORT.md) for how to connect and get into contact with the Power Gird Model project.


### PR DESCRIPTION
* Add Contribute page (Github Built-in) to the README
* Markdown dictates only one # (title header) per file