### PR TITLE
GitHub Actions: require actions to be pinned to full-length commit SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -24,6 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v2
+      uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0


### PR DESCRIPTION
This is part of our goal to follow security best practices. See also https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#using-third-party-actions

Cfr. https://docs.github.com/en/enterprise-cloud@latest/admin/enforcing-policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#controlling-access-to-public-actions-and-reusable-workflows :

> Require actions to be pinned to a full-length commit SHA: All actions must be pinned to a full-length commit SHA to be used. This includes actions from your enterprise and actions authored by GitHub. Reusable workflows can still be referenced by tag. For more information, see [Secure use reference](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#using-third-party-actions).

So we have to pin also the GitHub-owned (`actions/checkout`, ...) and PowerGridModel-owned action (`pgm-version-bump`) before we can enable enforcing.

Also adds dependabot

## Relates to:

* https://github.com/PowerGridModel/power-grid-model/pull/1372
* https://github.com/PowerGridModel/power-grid-model-io/pull/412
* https://github.com/PowerGridModel/power-grid-model-ds/pull/228
* https://github.com/PowerGridModel/pgm-build-dependencies/pull/15
* https://github.com/PowerGridModel/pgm-version-bump/pull/9
* https://github.com/PowerGridModel/power-grid-model-workshop/pull/56
* https://github.com/PowerGridModel/power-grid-model-benchmark/pull/17
* https://github.com/PowerGridModel/homebrew-pgm/pull/1