### PR TITLE
Fix bugs due to the latest version of PandaPower

### DIFF
--- a/generate_fictional_dataset.py
+++ b/generate_fictional_dataset.py
@@ -43,6 +43,15 @@ source_node = 0
 # opendss monitor
 opendss_monitor_mode = 32  # 0 for voltage, +32 for magnitude only
 
+LOAD_VOLTAGE_DEPENDENT_COLUMN_DEFAULTS = {
+    "const_z_percent": 0.0,
+    "const_i_percent": 0.0,
+    "const_z_p_percent": 0.0,
+    "const_i_p_percent": 0.0,
+    "const_z_q_percent": 0.0,
+    "const_i_q_percent": 0.0,
+}
+
 # cable parameter per km
 # 630Al XLPE 10 kV with neutral conductor
 cable_type = "630Al"
@@ -164,6 +173,18 @@ class LightSim2GridNetInput:
             pq=pq,
             ppci=ppci,
         )
+
+
+def _ensure_load_voltage_dependent_columns(load_df: pd.DataFrame) -> pd.DataFrame:
+    """Add missing pandapower voltage-dependent load columns with defaults."""
+    for column_name, default_value in LOAD_VOLTAGE_DEPENDENT_COLUMN_DEFAULTS.items():
+        if column_name not in load_df.columns:
+            load_df[column_name] = np.full(
+                shape=(load_df.shape[0],),
+                fill_value=default_value,
+                dtype=np.float64,
+            )
+    return load_df
 
 
 def generate_fictional_grid(
@@ -324,8 +345,8 @@ def generate_fictional_grid(
         },
         index=pgm_dataset["asym_load"]["id"] - n_line - n_node,
     )
-    pp_net.asymmetric_load = asym_load_df
-    pp_net_sym.load = sym_load_df
+    pp_net.asymmetric_load = _ensure_load_voltage_dependent_columns(asym_load_df)
+    pp_net_sym.load = _ensure_load_voltage_dependent_columns(sym_load_df)
 
     # dss
     dss_dict["Load"] = {

--- a/generate_fictional_dataset.py
+++ b/generate_fictional_dataset.py
@@ -499,6 +499,9 @@ def generate_fictional_grid(
         GRID2OP_CHRONICS_PATH = GRID2OP_PATH / "chronics" / "000"
         GRID2OP_CHRONICS_PATH.mkdir(exist_ok=True, parents=True)
 
+        pp_net_sym.line.loc[:, "name"] = [f"line_{line_index}" for line_index in pp_net_sym.line.index]
+        assert pp_net_sym.line["name"].is_unique
+
         pp_to_json(pp_net_sym, GRID2OP_PATH / "grid.json")
         with (GRID2OP_PATH / "config.py").open(mode="w", encoding="utf-8") as f:
             f.write(r"""from grid2op.Backend import PandaPowerBackend
@@ -509,7 +512,6 @@ config = {
     "chronics_class": Multifolder,
 }
 """)
-
         source_names = [
             f"gen_{g2o_node_id}_{g2o_source_id}"
             for g2o_source_id, g2o_node_id in enumerate(pgm_dataset["node"]["id"][:1])

--- a/generate_fictional_dataset.py
+++ b/generate_fictional_dataset.py
@@ -175,7 +175,7 @@ class LightSim2GridNetInput:
         )
 
 
-def _ensure_load_voltage_dependent_columns(load_df: pd.DataFrame) -> pd.DataFrame:
+def _make_load_voltage_dependent_columns(load_df: pd.DataFrame) -> pd.DataFrame:
     """Add missing pandapower voltage-dependent load columns with defaults."""
     for column_name, default_value in LOAD_VOLTAGE_DEPENDENT_COLUMN_DEFAULTS.items():
         if column_name not in load_df.columns:
@@ -345,8 +345,8 @@ def generate_fictional_grid(
         },
         index=pgm_dataset["asym_load"]["id"] - n_line - n_node,
     )
-    pp_net.asymmetric_load = _ensure_load_voltage_dependent_columns(asym_load_df)
-    pp_net_sym.load = _ensure_load_voltage_dependent_columns(sym_load_df)
+    pp_net.asymmetric_load = _make_load_voltage_dependent_columns(asym_load_df)
+    pp_net_sym.load = _make_load_voltage_dependent_columns(sym_load_df)
 
     # dss
     dss_dict["Load"] = {

--- a/generate_fictional_dataset.py
+++ b/generate_fictional_dataset.py
@@ -19,6 +19,7 @@ from pandapower.converter.pypower.to_ppc import to_ppc
 from pandapower.pf.makeYbus_numba import makeYbus
 from pandapower.pypower.idx_bus import VM, VA
 from pandapower.pypower.idx_gen import GEN_BUS, GEN_STATUS, VG
+from pandapower.pypower import idx_brch as pp_idx_brch
 from pandapower.pypower.bustypes import bustypes
 from pandapower.pypower.makeSbus import makeSbus
 
@@ -124,6 +125,21 @@ class LightSim2GridNetInput:
         bus = ppci["bus"]
         gen = ppci["gen"]
         branch = ppci["branch"]
+
+        required_branch_column_count = (
+            max(
+                value
+                for name, value in vars(pp_idx_brch).items()
+                if name.startswith("BR_") and isinstance(value, int)
+            )
+            + 1
+        )
+        if branch.shape[1] < required_branch_column_count:
+            padded_branch = np.zeros(
+                (branch.shape[0], required_branch_column_count), dtype=branch.dtype
+            )
+            padded_branch[:, : branch.shape[1]] = branch
+            branch = padded_branch
 
         if Version(pp.__version__) < Version("3"):
             ref, pv, pq = bustypes(bus, gen)


### PR DESCRIPTION
# What I did to find the bugs
1. `uv venv .venv && uv pip install --python .venv/bin/python -r requirements.txt`. The exact environment I used: [uvlock-file.zip](https://github.com/user-attachments/files/26783069/uvlock-file.zip).
2. Ran the notebook `Power Grid Model Benchmark.ipynb`.


# Bugs and fixes

## Bug 1: Mismatch between to_ppc and makeYbus

 **The bug:**
- `makeYbus` uses fixed branch-column indices from `pandapower.pypower.idx_brch` (for example `BR_R_ASYM`, `BR_X_ASYM`, `BR_G`, `BR_B`) inside `branch_vectors`.
- The `ppci["branch"]` matrix from `to_ppc(pp_net, init="flat")` had fewer columns than the highest required `BR_*` index.
- When `makeYbus` accessed these missing columns, numpy raised `IndexError` (`index 22` and then `index 23` out of bounds), so `LightSim2GridNetInput.from_pandapower_net` failed at `Ybus, _, _ = makeYbus(baseMVA, bus, branch)`.
- Both `makeYbus` and `to_ppc` are from PandaPower.

 **The fix:**
- In `generate_fictional_dataset.py`, the fix computes the required branch width dynamically as `max(BR_*) + 1` from `idx_brch`.
- If `branch.shape[1]` is smaller then `makeYbus` requires, fills the missing columns with zeros. This is a neutral default for those terms for asymmetric calculations and prevents out-of-bounds indexing.

**PandaPower version:** `3.3.3`.


## Bug 2: Missing columns in pandapower grid

 **The bug:**
- `grid2op` with `PandaPowerBackend` failed during initial `pp.runpp(...)` with `KeyError: 'const_z_p_percent'`.
- In this pandapower version, `_init_runpp_options` checks `net["load"]` for four ZIP-model columns: `const_z_p_percent`, `const_i_p_percent`, `const_z_q_percent`, and `const_i_q_percent`. These `const_*` columns are used to define the parts of load that behave as a constant impedance load or a constant current load.
- The generated grid (`g2o_grid_sym/grid.json`) was built from `pp_net_sym.load` that only had legacy columns (`const_z_percent`, `const_i_percent`) and did not include all required columns.

 **The fix:**
- Added `LOAD_VOLTAGE_DEPENDENT_COLUMN_DEFAULTS` in `generate_fictional_dataset.py` with legacy and split ZIP column names, all defaulting to `0.0`. This 0 defaults do not affect the benchmark results because these 0 defaults sets the load to constant power, which is a common setting for Power Flow calculations.
- Added `_ensure_load_voltage_dependent_columns(load_df)` to guarantee those columns exist in generated load DataFrames.

**PandaPower version:** `3.3.3`.
**Grid2Op version:** `1.12.3`.
## Bug 3: Duplicate line names in Grid2Op grid.json

 **The bug:**
- Grid2Op environment creation failed with EnvError: Two lines have the same names because `pp_net_sym.line["name"]` serialized as blank/duplicate names in `grid.json`.

 **The fix:**
- In `generate_fictional_dataset.py`, assign deterministic line names (`line_<index>`) before exporting grid.json and enforce uniqueness with `assert pp_net_sym.line["name"].is_unique`.

**PandaPower version:** `3.3.3`.
**Grid2Op version:** `1.12.3`.

